### PR TITLE
Add require in the generated initializer

### DIFF
--- a/lib/generators/phrase_ota/templates/phrase_ota.rb
+++ b/lib/generators/phrase_ota/templates/phrase_ota.rb
@@ -1,3 +1,5 @@
+require "phrase/ota"
+
 fallback_backend = I18n::Backend::Simple.new
 I18n.backend = I18n::Backend::Chain.new(Phrase::Ota::Backend.new, fallback_backend)
 


### PR DESCRIPTION
Needed to make `Phrase::Ota::*` available 