### PR TITLE
Init backend after configuring it

### DIFF
--- a/lib/generators/phrase_ota/templates/phrase_ota.rb
+++ b/lib/generators/phrase_ota/templates/phrase_ota.rb
@@ -1,7 +1,6 @@
 require "phrase/ota"
 
 fallback_backend = I18n::Backend::Simple.new
-I18n.backend = I18n::Backend::Chain.new(Phrase::Ota::Backend.new, fallback_backend)
 
 Phrase::Ota.configure do |config|
   # Possible datacenter values are "eu" and "us". The distribution_id and secret_token need to match the datacenter
@@ -22,3 +21,5 @@ Phrase::Ota.configure do |config|
   # Available locales that will be updated over-the-air
   config.available_locales = fallback_backend.available_locales
 end
+
+I18n.backend = I18n::Backend::Chain.new(Phrase::Ota::Backend.new, fallback_backend)


### PR DESCRIPTION
Fix order of initializing the backend. Before it was using the default poll interval for the first fetch when the class is created before the config is set