### PR TITLE
chore: fix publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@ca6063f4ed81b55db15b8c42d1b6f7925866342d # pin@3.7.11
+        id: release
         with:
           release-type: ruby
           package-name: phrase-ota-i18n


### PR DESCRIPTION
Set `id` to be able to use output `steps.release.outputs.release_created`