### PR TITLE
fix: translations are kept on backend init

### DIFF
--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -7,6 +7,7 @@ module Phrase
     class Backend < I18n::Backend::Simple
       def initialize
         @current_version = nil
+        @initialized = true # initializing immeditaly as we don't want to wait until all OTA translations have been fetched
         start_polling
       end
 
@@ -15,8 +16,6 @@ module Phrase
       end
 
       def init_translations
-        @translations = {}
-        @initialized = true
       end
 
       protected


### PR DESCRIPTION
The `translations` variable is already initialized. In addition, it seems this method is called on every request for yet unknown reasons and resetting the fetched translations