### PR TITLE
fix: use different current_version value per locale

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,3 @@
+fix: true
+parallel: true
+format: progress

--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -6,7 +6,7 @@ module Phrase
   module Ota
     class Backend < I18n::Backend::Simple
       def initialize
-        @current_version = nil
+        @current_locale_versions = {}
         @initialized = true # initializing immeditaly as we don't want to wait until all OTA translations have been fetched
         start_polling
       end
@@ -23,44 +23,48 @@ module Phrase
       def start_polling
         Thread.new do
           loop do
-            sleep(Phrase::Ota.config.poll_interval_seconds)
+            sleep(Phrase::Ota.config.poll_interval)
             update_translations
           end
         end
       end
 
       def update_translations
-        log("Phrase: Updating translations...")
+        log("Updating translations...")
 
         available_locales.each do |locale|
-          url = "#{Phrase::Ota.config.base_url}/#{Phrase::Ota.config.distribution_id}/#{Phrase::Ota.config.secret_token}/#{locale}/yml"
           params = {
             app_version: Phrase::Ota.config.app_version,
             client: "ruby",
             sdk_version: Phrase::Ota::VERSION
           }
-          params[:current_version] = @current_version unless @current_version.nil?
+          current_version = @current_locale_versions[locale]
+          params[:current_version] = current_version unless current_version.nil?
 
           connection = Faraday.new do |faraday|
             faraday.use FaradayMiddleware::FollowRedirects
             faraday.adapter Faraday.default_adapter
           end
 
-          log("Phrase: Fetching URL: #{url}")
+          uri = URI("#{Phrase::Ota.config.base_url}/#{Phrase::Ota.config.distribution_id}/#{Phrase::Ota.config.secret_token}/#{locale}/yml")
+          uri.query = URI.encode_www_form(params)
+          url = uri.to_s
+          log("Request URL: #{url}")
 
-          response = connection.get(url, params, {"User-Agent" => "phrase-ota-i18n #{Phrase::Ota::VERSION}"})
+          response = connection.get(url, {}, {"User-Agent" => "phrase-ota-i18n #{Phrase::Ota::VERSION}"})
           next unless response.status == 200
 
-          @current_version = CGI.parse(URI(response.env.url).query)["version"].first.to_i
+          @current_locale_versions[locale] = CGI.parse(URI(response.env.url).query)["version"].first.to_i
           yaml = YAML.safe_load(response.body)
           yaml.each do |yaml_locale, tree|
-            store_translations(yaml_locale, tree || {})
+            store_translations(locale, tree || {})
+            log("Updated locale: #{locale}")
           end
         end
       end
 
       def log(message)
-        Phrase::Ota.config.logger.info(message) if Phrase::Ota.config.debug
+        Phrase::Ota.config.logger.info("Phrase OTA: #{message}") if Phrase::Ota.config.debug
       end
     end
   end

--- a/lib/phrase/ota/configuration.rb
+++ b/lib/phrase/ota/configuration.rb
@@ -9,7 +9,7 @@ module Phrase
       attr_accessor :secret_token
       attr_accessor :logger
       attr_accessor :app_version
-      attr_accessor :poll_interval_seconds
+      attr_accessor :poll_interval
       attr_accessor :datacenter
       attr_accessor :available_locales
       attr_accessor :debug
@@ -20,7 +20,7 @@ module Phrase
         @secret_token = nil
         @logger = Logger.new($stdout)
         @app_version = nil
-        @poll_interval_seconds = 60
+        @poll_interval = 60
         @datacenter = "eu"
         @available_locales = []
         @base_url = nil

--- a/spec/phrase/ota/backend_spec.rb
+++ b/spec/phrase/ota/backend_spec.rb
@@ -23,6 +23,7 @@ describe Phrase::Ota::Backend do
       config.available_locales = []
     end
     I18n.backend = @previous_backend
+    I18n.config.clear_available_locales_set
   end
 
   context "#available_locales" do
@@ -42,7 +43,7 @@ describe Phrase::Ota::Backend do
 
       context "translations should be updated" do
         before do
-          stub_request(:get, url_en).to_return(status: 200, body: body_en, headers: {})
+          stub_request(:get, url_en).to_return(status: 200, body: body_en)
         end
 
         it do
@@ -56,8 +57,8 @@ describe Phrase::Ota::Backend do
         let(:body_en_2) { {"en" => {"lorem" => "Hello OTA New"}}.to_yaml }
 
         before do
-          stub_request(:get, url_en).to_return(status: 200, body: body_en, headers: {})
-          stub_request(:get, url_en_2).to_return(status: 200, body: body_en_2, headers: {})
+          stub_request(:get, url_en).to_return(status: 200, body: body_en)
+          stub_request(:get, url_en_2).to_return(status: 200, body: body_en_2)
         end
 
         it do
@@ -69,6 +70,29 @@ describe Phrase::Ota::Backend do
 
           subject.send(:update_translations)
           expect(I18n.t(:lorem, locale: :en)).to eq("Hello OTA New")
+        end
+      end
+
+      context "store current_version per locale" do
+        let(:available_locales) { [:en, :fr] }
+        let(:body_fr) { {"fr" => {"lorem" => "Bonjour le monde"}}.to_yaml }
+        let(:url_fr) { "https://ota.eu.phrase.com/#{distribution_id}/#{secret_token}/fr/yml?app_version&client=ruby&sdk_version=#{Phrase::Ota::VERSION}" }
+        let(:url_en_2) { "https://ota.eu.phrase.com/#{distribution_id}/#{secret_token}/en/yml?app_version&client=ruby&current_version=0&sdk_version=#{Phrase::Ota::VERSION}" }
+
+        before do
+          stub_request(:get, url_en).to_return(status: 200, body: body_en)
+          stub_request(:get, url_en_2).to_return(status: 200, body: body_en)
+          stub_request(:get, url_fr).to_return({status: 404}, {status: 200, body: body_fr})
+        end
+
+        it do
+          subject.send(:update_translations)
+          expect(I18n.t(:lorem, locale: :en)).to eq("Hello OTA")
+          expect(I18n.t(:lorem, locale: :fr)).to eq("Translation missing: fr.lorem")
+
+          subject.send(:update_translations)
+          expect(I18n.t(:lorem, locale: :en)).to eq("Hello OTA")
+          expect(I18n.t(:lorem, locale: :fr)).to eq("Bonjour le monde")
         end
       end
     end


### PR DESCRIPTION
- Not all locales need to be included in every releases. E.g. `en` could be part of the release `8`, while `de` might use `7` as the latest current version. This could affect whether whether a locale is updated and we need to store the latest fetched version for each locale
- Use a unique cache key per distribution/env/locale. This will prevent issues in case the distribution or secret token should be changed during runtime
- Change `poll_interval_seconds` variable to `poll_interval`. Allows for a more readable usage like `poll_interval = 10.seconds`. Although this is a breaking change I would avoid a major version bump as the library is not generally available yet