### PR TITLE
chore: support faraday 2.x

### DIFF
--- a/lib/phrase/ota/backend.rb
+++ b/lib/phrase/ota/backend.rb
@@ -1,5 +1,5 @@
 require "faraday"
-require "faraday_middleware"
+require 'faraday/follow_redirects'
 require "i18n"
 
 module Phrase
@@ -42,7 +42,7 @@ module Phrase
           params[:current_version] = current_version unless current_version.nil?
 
           connection = Faraday.new do |faraday|
-            faraday.use FaradayMiddleware::FollowRedirects
+            faraday.response :follow_redirects
             faraday.adapter Faraday.default_adapter
           end
 

--- a/phrase-ota-i18n.gemspec
+++ b/phrase-ota-i18n.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "i18n"
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "faraday-follow_redirects"
 end


### PR DESCRIPTION
fixes: #20 

This gem has been confined to the 1.X branch of Faraday due to its dependency on the deprecated faraday_middleware, which is incompatible with Faraday 2.X. This commit addresses the issue by replacing faraday_middleware with faraday-follow_redirects, which is compatible with both Faraday 2.X and 1.X.